### PR TITLE
lindaとのやりとりをsocket.ioのみに一本化した

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hubot-scripts": ">= 2.5.0 < 3.0.0",
     "hubot-slack": "^2.1.0",
     "linda-socket.io": "~0.2.0",
+    "lodash": "^2.4.1",
     "request": "^2.36.0",
     "socket.io-client": "~0.9.16"
   },

--- a/scripts/linda-door.coffee
+++ b/scripts/linda-door.coffee
@@ -1,6 +1,3 @@
-request = require 'request'
-url = "http://node-linda-base.herokuapp.com"
-
 module.exports = (robot) ->
   robot.respond /([a-z_\-]+) ドア(開けて|閉めて)/i, (msg) ->
     space = msg.match[1]
@@ -8,14 +5,12 @@ module.exports = (robot) ->
       when "開けて" then "open"
       when "閉めて" then "close"
 
-    post_data = {
-      url: "#{url}/#{space}",
-      form: {tuple: JSON.stringify({type: "door", cmd: cmd})}
-    }
-    request.post post_data, (err, res) ->
+    robot.linda.read_with_timeout space, {type: "door", cmd: cmd, response: "success"}, 5000, (err, tuple) ->
       if err
         msg.send "ドアには・・勝てなかったよ（失敗）"
         return
       msg.send switch cmd
         when "open" then "開けたと思う"
         when "close" then "閉めたと思う"
+
+    robot.linda.tuplespace(space).write {type: "door", cmd: cmd}

--- a/scripts/linda-macsay.coffee
+++ b/scripts/linda-macsay.coffee
@@ -1,32 +1,15 @@
-request = require 'request'
-async = require 'async'
-url = "http://node-linda-base.herokuapp.com"
-
-spaces = ["delta", "iota", "tau", "masuilab", "shokai"]
-
-say = (space, str, callback = ->) ->
-  post_data = {
-    url: "#{url}/#{space}",
-    form: {tuple: JSON.stringify({type: "say", value: str})}
-  }
-  request.post post_data, callback
+_ = require 'lodash'
 
 module.exports = (robot) ->
   robot.respond /([a-z_\-]+) say ([^\s]+)/i, (msg) ->
     space = msg.match[1]
     str = msg.match[2]
-    say space, str, (err, res) ->
-      if err
-        msg.send "#{space}に「#{str}」って言うの失敗した"
-        return
-      msg.send "#{space}に「#{str}」って言っといてやったわ、感謝しなさい"
+    robot.linda.tuplespace(space).write {type: "say", value: str}
+    msg.send "#{space}に「#{str}」って言っといてやったわ、感謝しなさい"
 
   robot.respond /say ([^\s]+)/i, (msg) ->
     str = msg.match[1]
-    async.map spaces, (space, callback) ->
-      say space, str, callback
-    , (err, res) ->
-      if err
-        msg.send "#{spaces.join('と')}に「#{str}」って言うの失敗した"
-        return
-      msg.send "#{spaces.join('と')}に「#{str}」って言っといてやったわ、感謝しなさい"
+    for name, yomi of robot.linda.config.spaces
+      robot.linda.tuplespace(name).write {type: "say", value: str}
+    to = _.keys(robot.linda.config.spaces).join("と")
+    msg.send "#{to}に「#{str}」って言っといてやったわ、感謝しなさい"

--- a/scripts/linda.coffee
+++ b/scripts/linda.coffee
@@ -1,6 +1,11 @@
-config = {
+config =
   url: "http://node-linda-base.herokuapp.com"
-}
+  space: "masuilab"  # main
+  spaces :
+    delta : "デルタ"  # 名前と読み仮名
+    iota  : "イオタ"
+    tau   : "タウ"
+    shokai: "しょうかいハウス"
 
 module.exports = (robot) ->
   LindaClient = require('linda-socket.io').Client
@@ -18,7 +23,9 @@ module.exports = (robot) ->
       cid = null
       callback(err, tuple)
     setTimeout ->
-      ts.cancel cid if cid
+      if cid
+        ts.cancel cid
+        callback "timeout"
     , msec
 
   robot.respond /linda/i, (msg) ->


### PR DESCRIPTION
#7 を実装しました。httpをやめて1つのsocket.ioのコネクションを共有するようにしました
- install `lodash` npm
- `robot.linda.config.spaces` を名前:読み仮名の連想配列に変更
- use socket.io on `scripts/linda-macsay.coffee`
- use socket.io on `scripts/linda-door.coffee`
- bugfix "timeout" of `robot.linda.read_with_timeout`

hubotに送るコマンドは変更なしです
